### PR TITLE
bump terraform-equinix-fabric-connection module version to 0.4.0

### DIFF
--- a/examples/fabric-port-connection/variables.tf
+++ b/examples/fabric-port-connection/variables.tf
@@ -18,7 +18,7 @@ variable "equinix_provider_client_secret" {
 
 variable "gcp_project" {
   type        = string
-  description = "(Required) Name of the GCP project to manage resources in."
+  description = "(Required) ID of the GCP project to manage resources in."
 }
 
 variable "fabric_port_name" {

--- a/examples/network-edge-device-connection/variables.tf
+++ b/examples/network-edge-device-connection/variables.tf
@@ -18,7 +18,7 @@ variable "equinix_provider_client_secret" {
 
 variable "gcp_project" {
   type        = string
-  description = "(Required) Name of the GCP project to manage resources in."
+  description = "(Required) ID of the GCP project to manage resources in."
 }
 
 variable "device_id" {

--- a/examples/service-token-metal-to-gcp-connection/variables.tf
+++ b/examples/service-token-metal-to-gcp-connection/variables.tf
@@ -18,7 +18,7 @@ variable "equinix_provider_client_secret" {
 
 variable "gcp_project" {
   type        = string
-  description = "(Required) Name of the GCP project to manage resources in."
+  description = "(Required) ID of the GCP project to manage resources in."
 }
 
 variable "gcp_region" {

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "google_compute_interconnect_attachment" "this" {
 
 module "equinix-fabric-connection" {
   source  = "equinix-labs/fabric-connection/equinix"
-  version = "0.3.1"
+  version = "0.4.0"
 
   # required variables
   notification_users = var.fabric_notification_users

--- a/variables.tf
+++ b/variables.tf
@@ -136,7 +136,7 @@ variable "gcp_region" {
 
 variable "gcp_project" {
   type        = string
-  description = "The project in which the GCP resources resides. If it is not provided, the provider project is used."
+  description = "ID of the project in which the GCP resources resides. If it is not provided, the provider project is used."
   default     = ""
 }
 


### PR DESCRIPTION
Note: In fabric connection modules for cloud providers all the connection logic happens in submodule `terraform-equinix-fabric-connection`, therefore user-agent will include the `terraform-equinix-fabric-connection` metadata module name and not `terraform-equinix-fabric-connection-gcp` in this case. 