### PR TITLE
fix: update module outputs to match what they were before v0.3.0

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -13,15 +13,11 @@ output "fabric_connection_status" {
   value       = module.equinix-fabric-connection.primary_connection.state
 }
 
-output "fabric_connection_equinix_status" {
-  description = "Connection equinix status."
-  value       = module.equinix-fabric-connection.primary_connection.operation.equinix_status
+output "fabric_connection_equinix_operation" {
+  description = "Connection operation status object."
+  value       = module.equinix-fabric-connection.primary_connection.operation
 }
 
-output "fabric_connection_provider_status" {
-  description = "Connection provisioning provider status."
-  value       = module.equinix-fabric-connection.primary_connection.operation.provider_status
-}
 
 output "fabric_connection_bandwidth" {
   description = "Connection bandwidth in Mbps"
@@ -30,12 +26,12 @@ output "fabric_connection_bandwidth" {
 
 output "fabric_connection_seller_metro" {
   description = "Connection seller metro code."
-  value       = module.equinix-fabric-connection.primary_connection.z_side.access_point.location.metro_code
+  value       = [for i in module.equinix-fabric-connection.primary_connection.z_side : [for j in i.access_point : [for k in j.location : k.metro_code]]]
 }
 
 output "fabric_connection_seller_region" {
   description = "Connection seller region."
-  value       = module.equinix-fabric-connection.primary_connection.z_side.access_point.seller_region
+  value       = [for i in module.equinix-fabric-connection.primary_connection.z_side : [for j in i.access_point : j.seller_region]]
 }
 
 output "network_edge_bgp_state" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,29 +9,28 @@ output "fabric_connection_name" {
 }
 
 output "fabric_connection_status" {
-  description = "Connection overall state."
-  value       = module.equinix-fabric-connection.primary_connection.state
+  description = "Connection provisioning status."
+  value       = tolist(module.equinix-fabric-connection.primary_connection.operation)[0].equinix_status
 }
 
-output "fabric_connection_equinix_operation" {
-  description = "Connection operation status object."
-  value       = module.equinix-fabric-connection.primary_connection.operation
+output "fabric_connection_provider_status" {
+  description = "Connection provisioning provider status."
+  value       = tolist(module.equinix-fabric-connection.primary_connection.operation)[0].provider_status
 }
 
-
-output "fabric_connection_bandwidth" {
-  description = "Connection bandwidth in Mbps"
+output "fabric_connection_speed" {
+  description = "Connection speed in Mbps"
   value       = module.equinix-fabric-connection.primary_connection.bandwidth
 }
 
 output "fabric_connection_seller_metro" {
   description = "Connection seller metro code."
-  value       = [for i in module.equinix-fabric-connection.primary_connection.z_side : [for j in i.access_point : [for k in j.location : k.metro_code]]]
+  value       = flatten([for i in module.equinix-fabric-connection.primary_connection.z_side : [for j in i.access_point : [for k in j.location : k.metro_code]]])[0]
 }
 
 output "fabric_connection_seller_region" {
   description = "Connection seller region."
-  value       = [for i in module.equinix-fabric-connection.primary_connection.z_side : [for j in i.access_point : j.seller_region]]
+  value       = flatten([for i in module.equinix-fabric-connection.primary_connection.z_side : [for j in i.access_point : j.seller_region]])[0]
 }
 
 output "network_edge_bgp_state" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,33 +9,33 @@ output "fabric_connection_name" {
 }
 
 output "fabric_connection_status" {
-  description = "Connection provisioning status."
-  value       = module.equinix-fabric-connection.primary_connection.status
+  description = "Connection overall state."
+  value       = module.equinix-fabric-connection.primary_connection.state
+}
+
+output "fabric_connection_equinix_status" {
+  description = "Connection equinix status."
+  value       = module.equinix-fabric-connection.primary_connection.operation.equinix_status
 }
 
 output "fabric_connection_provider_status" {
   description = "Connection provisioning provider status."
-  value       = module.equinix-fabric-connection.primary_connection.provider_status
+  value       = module.equinix-fabric-connection.primary_connection.operation.provider_status
 }
 
-output "fabric_connection_speed" {
-  description = "Connection speed."
-  value       = module.equinix-fabric-connection.primary_connection.speed
-}
-
-output "fabric_connection_speed_unit" {
-  description = "Connection speed unit."
-  value       = module.equinix-fabric-connection.primary_connection.speed_unit
+output "fabric_connection_bandwidth" {
+  description = "Connection bandwidth in Mbps"
+  value       = module.equinix-fabric-connection.primary_connection.bandwidth
 }
 
 output "fabric_connection_seller_metro" {
   description = "Connection seller metro code."
-  value       = module.equinix-fabric-connection.primary_connection.seller_metro_code
+  value       = module.equinix-fabric-connection.primary_connection.z_side.access_point.location.metro_code
 }
 
 output "fabric_connection_seller_region" {
   description = "Connection seller region."
-  value       = module.equinix-fabric-connection.primary_connection.seller_region
+  value       = module.equinix-fabric-connection.primary_connection.z_side.access_point.seller_region
 }
 
 output "network_edge_bgp_state" {


### PR DESCRIPTION
In v0.3.0 of this module, we upgraded from the old ECX-v3-based [terraform-equinix-fabric-connection](https://github.com/equinix-labs/terraform-equinix-fabric-connection) to the new Fabric-v4-based module.  The Fabric terraform resources are not drop-in replacements for ECX, so the upgrade introduced an unnoticed error in this module's outputs.

This updates the module outputs to reference the correct attributes in the new Fabric resources and to remove outputs that are no longer available due to changes in the resources and/or the underlying API.